### PR TITLE
fix bug:crash when send text message before apply for camera permission.

### DIFF
--- a/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/ChatInputView.java
+++ b/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/ChatInputView.java
@@ -341,7 +341,7 @@ public class ChatInputView extends LinearLayout
                 if (onSubmit()) {
                     mChatInput.setText("");
                 }
-                if (mSelectPhotoView.getSelectFiles().size() > 0) {
+                if (mSelectPhotoView.getSelectFiles() != null && mSelectPhotoView.getSelectFiles().size() > 0) {
                     mListener.onSendFiles(mSelectPhotoView.getSelectFiles());
 
                     mSendBtn.setImageDrawable(ContextCompat.getDrawable(getContext(),


### PR DESCRIPTION
解决问题：在应用成功申请照相机使用权限前，如果发送文字消息会导致应用崩溃。