### PR TITLE
can not show soft keyboard when first click chat input box

### DIFF
--- a/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/ChatInputView.java
+++ b/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/ChatInputView.java
@@ -246,6 +246,7 @@ public class ChatInputView extends LinearLayout
                 if (motionEvent.getAction() == MotionEvent.ACTION_DOWN && !mShowSoftInput) {
                     mShowSoftInput = true;
                     invisibleMenuLayout();
+                    mChatInput.requestFocus();
                 }
                 return false;
             }


### PR DESCRIPTION
在聊天文字输入框未获得焦点的情况下，点击输入框会弹出聊天输入面板但不会弹出软键盘（此时输入面板显示空白）。