### PR TITLE
修改错误TextureView doesn't support displaying a background drawable.

### DIFF
--- a/Android/chatinput/src/main/res/layout/layout_chatinput_camera.xml
+++ b/Android/chatinput/src/main/res/layout/layout_chatinput_camera.xml
@@ -8,6 +8,7 @@
     <TextureView
         android:id="@+id/aurora_txtv_camera_texture"
         android:layout_width="match_parent"
+        android:background="@null"
         android:layout_height="match_parent" />
 
     <ImageButton


### PR DESCRIPTION
在华为荣耀9上，在我的项目中引用ChatInput类会报TextureView doesn't support displaying a background drawable. 参考如下
https://stackoverflow.com/questions/43705434/android-nougat-textureview-doesnt-support-displaying-a-background-drawable