### PR TITLE
fix TextureView doesn't support displaying a background drawable

### DIFF
--- a/Android/chatinput/src/main/res/layout/layout_chatinput_camera.xml
+++ b/Android/chatinput/src/main/res/layout/layout_chatinput_camera.xml
@@ -8,6 +8,7 @@
     <TextureView
         android:id="@+id/aurora_txtv_camera_texture"
         android:layout_width="match_parent"
+        android:background="@null"
         android:layout_height="match_parent" />
 
     <ImageButton


### PR DESCRIPTION
在我个人项目中引用chatinput报错TextureView doesn't support displaying a background drawable
解决方案参考如下
https://stackoverflow.com/questions/43705434/android-nougat-textureview-doesnt-support-displaying-a-background-drawable