### PR TITLE
修复使用全屏拍照引发闪退问题。

### DIFF
--- a/iOS/IMUIInputView/Views/IMUICameraCell.swift
+++ b/iOS/IMUIInputView/Views/IMUICameraCell.swift
@@ -53,7 +53,10 @@ class IMUICameraCell: UICollectionViewCell, IMUIFeatureCellProtocol {
     cameraView.shootPictureCallback = { imageData in
       self.featureDelegate?.didShotPicture(with: imageData)
       if self.isFullScreenMode {
-        self.shrinkDownScreen()
+        // Switch to main thread operation UI
+        DispatchQueue.main.sync {
+            self.shrinkDownScreen()
+        }
         self.isFullScreenMode = false
       }
     }


### PR DESCRIPTION
`cameraView.onClickFullSizeCallback` 回调不是在主线程执行: *Thread.current.isMainThread:false*，但`self.shrinkDownScreen()` 函数将会操作UI，故引发闪退；
将 `self.shrinkDownScreen()` 放在主线程执行可修复此问题。