### PR TITLE
修复 Android 版混淆打包后 emoji 页显示空白

### DIFF
--- a/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/utils/SimpleCommonUtils.java
+++ b/Android/chatinput/src/main/java/cn/jiguang/imui/chatinput/utils/SimpleCommonUtils.java
@@ -160,7 +160,7 @@ public class SimpleCommonUtils {
                     pageView.setNumColumns(pageEntity.getRow());
                     pageEntity.setRootView(pageView);
                     try {
-                        EmoticonsAdapter adapter = (EmoticonsAdapter) newInstance(_class, container.getContext(), pageEntity, onEmoticonClickListener);
+                        EmoticonsAdapter adapter = new EmoticonsAdapter(container.getContext(), pageEntity, onEmoticonClickListener);
                         if (emoticonDisplayListener != null) {
                             adapter.setOnDisPlayListener(emoticonDisplayListener);
                         }


### PR DESCRIPTION
只改了一行：
```java
EmoticonsAdapter adapter = new EmoticonsAdapter(container.getContext(), pageEntity, onEmoticonClickListener);
```